### PR TITLE
mnt: added GCC>=10 mismatch flags

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,13 @@ echo "Running with mpi=$mpi and blas=$blas_impl"
 cd Obj
 ../Src/obj_setup.sh
 
+gcc_version=$(gcc --version | head -1 | awk '{print $3}')
+# Check if we have a gcc version >= 10
+gcc_version=${gcc_version%%\.*}
+if [[ $gcc_version -ge 10 ]]; then
+    FFLAGS="$FFLAGS -fallow-argument-mismatch"
+fi
+
 if [[ "$mpi" != "nompi" ]]; then
     export CFLAGS=${CFLAGS//-fopenmp/}
     export FFLAGS=${FFLAGS//-fopenmp/}
@@ -35,6 +42,7 @@ repl="$repl;s:%FFLAGS%:$FFLAGS:g"
 repl="$repl;s:%FFLAGS_DEBUG%:$DEBUG_FFLAGS:g"
 repl="$repl;s:%INCFLAGS%:-I$PREFIX/include:g"
 repl="$repl;s:%LDFLAGS%:-L$PREFIX/lib:g"
+
 
 if [[ "$mpi" == "nompi" ]]; then
     sed -e "$repl" $RECIPE_DIR/arch.make.SEQ > arch.make

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,11 +9,15 @@ echo "Running with mpi=$mpi and blas=$blas_impl"
 cd Obj
 ../Src/obj_setup.sh
 
-gcc_version=$(gcc --version | head -1 | awk '{print $3}')
+if [[ -n "$GCC" ]]; then
+    gcc_version=$($GCC --version | head -1 | awk '{print $3}')
+else
+    gcc_version=$($CC --version | head -1 | awk '{print $3}')
+fi
 # Check if we have a gcc version >= 10
 gcc_version=${gcc_version%%\.*}
 if [[ $gcc_version -ge 10 ]]; then
-    FFLAGS="$FFLAGS -fallow-argument-mismatch"
+    export FFLAGS="$FFLAGS -fallow-argument-mismatch"
 fi
 
 if [[ "$mpi" != "nompi" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/makefile_ncdf-serial.patch
 
 # Default build version to be stepped with every new build!
-{% set build = 2 %}
+{% set build = 3 %}
 
 # Define build matrix for MPI vs. non-mpi
 ## ensure mpi is defined (needed for conda-smithy recipe-lint)


### PR DESCRIPTION
Signed-off-by: zerothi <nickpapior@gmail.com>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Allowing argument-mismatch in flags
<!--
Please add any other relevant info below:
-->
