### PR TITLE
Added elpa support

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -15,13 +15,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
 libnetcdf:
 - 4.9.2
+lua:
+- '5'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -15,13 +15,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
 libnetcdf:
 - 4.9.2
+lua:
+- '5'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -15,13 +15,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
 libnetcdf:
 - 4.9.2
+lua:
+- '5'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/migrations/hdf51142.yaml
+++ b/.ci_support/migrations/hdf51142.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.14.2
-migrator_ts: 1692590899.44706

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -13,13 +13,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
 libnetcdf:
 - 4.9.2
+lua:
+- '5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -13,13 +13,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
 libnetcdf:
 - 4.9.2
+lua:
+- '5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -13,13 +13,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
 libnetcdf:
 - 4.9.2
+lua:
+- '5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+# Ignore all files and folders in root
+*
+!/conda-forge.yml
+
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
+!/recipe/**
+!/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -79,6 +79,9 @@ cmake_opts=(
   # MPI
   "-DWITH_MPI=${MPI}"
 
+  # ELPA
+  "-DWITH_ELPA=${MPI}"
+
   # We will fetch the compatible versions
   "-DLIBFDF_FIND_METHOD=fetch"
   "-DLIBGRIDXC_FIND_METHOD=fetch"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/include_lua.patch
 
 # Default build version to be stepped with every new build!
-{% set build = 1 %}
+{% set build = 2 %}
 
 # Define build matrix for MPI vs. non-mpi
 ## ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -61,6 +61,7 @@ requirements:
     - netcdf-fortran
     - netcdf-fortran * {{ mpi_prefix }}_*
     - lua
+    - elpa * {{ mpi_prefix }}_* # [mpi != 'nompi']
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - scalapack  # [mpi != 'nompi']
@@ -69,6 +70,7 @@ requirements:
     - libnetcdf * {{ mpi_prefix }}_*
     - netcdf-fortran * {{ mpi_prefix }}_*
     - lua
+    - elpa * {{ mpi_prefix }}_* # [mpi != 'nompi']
 test:
   source_files:
     - Tests/**

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     - netcdf-fortran
     - netcdf-fortran * {{ mpi_prefix }}_*
     - lua
-    - elpa * {{ mpi_prefix }}_* # [mpi != 'nompi']
+    - elpa * {{ mpi_prefix }}_*  # [mpi != 'nompi']
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - scalapack  # [mpi != 'nompi']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ requirements:
     - libnetcdf * {{ mpi_prefix }}_*
     - netcdf-fortran * {{ mpi_prefix }}_*
     - lua
-    - elpa * {{ mpi_prefix }}_* # [mpi != 'nompi']
+    - elpa * {{ mpi_prefix }}_*  # [mpi != 'nompi']
 test:
   source_files:
     - Tests/**


### PR DESCRIPTION
`elpa` is added as a dependency and it is found automatically through `pkg-config`. I just had to fix a little bug in the pkg-config files (https://github.com/conda-forge/elpa-feedstock/pull/25).

Maybe later we can just add `elsi` as  proposed in https://github.com/conda-forge/siesta-feedstock/issues/30, I don't know how ELSI support works exactly :sweat_smile: 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
